### PR TITLE
[8.x] Fixes missing exception property

### DIFF
--- a/src/Http/Middleware/CatchDefaultRoute.php
+++ b/src/Http/Middleware/CatchDefaultRoute.php
@@ -24,7 +24,7 @@ class CatchDefaultRoute
 
         $response = $next($request);
 
-        if (! \is_null($response->exception) && $response->exception instanceof NotFoundHttpException) {
+        if (property_exists($response, 'exception') && ! \is_null($response->exception) && $response->exception instanceof NotFoundHttpException) {
             if ($request->decodedPath() === '/' && $workbench['start'] !== '/') {
                 return redirect($workbench['start']);
             }


### PR DESCRIPTION
This pull request fixes the usage of this middleware, when responses are native symfony responses without `exception` property.